### PR TITLE
Make sure we pass a locale-agnostic string to Decimal()

### DIFF
--- a/src/python/bytesize.py
+++ b/src/python/bytesize.py
@@ -4,6 +4,8 @@ from ctypes import POINTER, byref
 import six
 from decimal import Decimal
 
+import locale
+
 import gettext
 _ = lambda x: gettext.translation("libbytesize", fallback=True).gettext(x) if x != "" else ""
 
@@ -356,9 +358,15 @@ class Size(object):
             real_unit = unit_strs.get(unit)
             if real_unit is None:
                 raise ValueError("Invalid unit specification: '%s'" % unit)
-            return Decimal(self._c_size.convert_to(real_unit))
+            ret = self._c_size.convert_to(real_unit)
         else:
-            return Decimal(self._c_size.convert_to(unit))
+            ret = self._c_size.convert_to(unit)
+
+        radix = locale.nl_langinfo(locale.RADIXCHAR)
+        if radix != '.':
+            ret = ret.replace(radix, '.')
+
+        return Decimal(ret)
 
     def human_readable(self, min_unit=B, max_places=2, xlate=True):
         if isinstance(min_unit, six.string_types):

--- a/tests/lbs_py_override_unittest.py
+++ b/tests/lbs_py_override_unittest.py
@@ -3,12 +3,20 @@
 
 import unittest
 import copy
+import locale
 
 from decimal import Decimal
 
 from bytesize import Size
 
 class SizeTestCase(unittest.TestCase):
+
+    def setUp(self):
+        locale.setlocale(locale.LC_ALL,'en_US.utf8')
+        self.addCleanup(self._clean_up)
+
+    def _clean_up(self):
+        locale.setlocale(locale.LC_ALL,'en_US.utf8')
 
     # test operator functions
     def testOperatorPlus(self):
@@ -251,6 +259,24 @@ class SizeTestCase(unittest.TestCase):
 
         size_set = set((Size("1 KiB"), Size("1 KiB"), Size("1 KiB"), Size("2 KiB"), Size(0)))
         self.assertEqual(len(size_set), 3)
+
+    def testConvertTo(self):
+        size = Size("1.5 KiB")
+        conv = size.convert_to("KiB")
+        self.assertEqual(conv, Decimal("1.5"))
+
+        locale.setlocale(locale.LC_ALL,'cs_CZ.UTF-8')
+        size = Size("1.5 KiB")
+        conv = size.convert_to("KiB")
+        self.assertEqual(conv, Decimal("1.5"))
+
+        # this persian locale uses a two-byte unicode character for the radix
+        locale.setlocale(locale.LC_ALL, 'ps_AF.UTF-8')
+        size = Size("1.5 KiB")
+        conv = size.convert_to("KiB")
+        self.assertEqual(conv, Decimal("1.5"))
+
+        locale.setlocale(locale.LC_ALL,'en_US.UTF-8')
 
 #endclass
 


### PR DESCRIPTION
Decimal() doesn't take into account the current locale, but we get a localized result from bs_convert_to().

Fixes issue #6 