### PR TITLE
Fix comparison (#1326113)

### DIFF
--- a/src/bs_size.c
+++ b/src/bs_size.c
@@ -1027,10 +1027,17 @@ BSSize bs_size_round_to_nearest (const BSSize size, const BSSize round_to, BSRou
  *          @size2 respectively comparing absolute values if @abs is %true
  */
 int bs_size_cmp (const BSSize size1, const BSSize size2, bool abs) {
+    int ret = 0;
     if (abs)
-        return mpz_cmpabs (size1->bytes, size2->bytes);
+        ret = mpz_cmpabs (size1->bytes, size2->bytes);
     else
-        return mpz_cmp (size1->bytes, size2->bytes);
+        ret = mpz_cmp (size1->bytes, size2->bytes);
+    /* make sure we don't return things like 2 or -2 (which GMP can give us) */
+    if (ret > 0)
+        ret = 1;
+    else if (ret < 0)
+        ret = -1;
+    return ret;
 }
 
 /**
@@ -1044,8 +1051,15 @@ int bs_size_cmp (const BSSize size1, const BSSize size2, bool abs) {
  *          @bytes respectively comparing absolute values if @abs is %true
  */
 int bs_size_cmp_bytes (const BSSize size, uint64_t bytes, bool abs) {
+    int ret = 0;
     if (abs)
-        return mpz_cmpabs_ui (size->bytes, bytes);
+        ret = mpz_cmpabs_ui (size->bytes, bytes);
     else
-        return mpz_cmp_ui (size->bytes, bytes);
+        ret = mpz_cmp_ui (size->bytes, bytes);
+    /* make sure we don't return things like 2 or -2 (which GMP can give us) */
+    if (ret > 0)
+        ret = 1;
+    else if (ret < 0)
+        ret = -1;
+    return ret;
 }

--- a/src/python/bytesize.py
+++ b/src/python/bytesize.py
@@ -397,7 +397,7 @@ class Size(object):
         if isinstance(other, six.integer_types):
             if (other < 0 and abs_vals):
                 other = abs(other)
-            if other <= MAXUINT64 and other > 0:
+            if 0 <= other <= MAXUINT64:
                 return self._c_size.cmp_bytes(other, abs_vals)
             else:
                 other = SizeStruct.new_from_str(str(other))


### PR DESCRIPTION
This fixes the issue that ``Size("10 GiB") > 0`` was returning ``False`` on 32bit systems. The reason is that the *GMP* function used in the implementation returns ``2`` instead of ``1`` on 32bit systems. However, their documentation says that it can be any number smaller/greater than 0 or 0. So the issue is on our side.