### PR TITLE
Fix issues with radix char different from "." (#1326108)

### DIFF
--- a/src/bs_size.c
+++ b/src/bs_size.c
@@ -750,17 +750,24 @@ BSSize bs_size_mul_float_str (const BSSize size, const char *float_str, BSError 
     mpf_t op1, op2;
     int status = 0;
     BSSize ret = NULL;
+    const char *radix_char = NULL;
+    char *loc_float_str = NULL;
+
+    radix_char = nl_langinfo (RADIXCHAR);
 
     mpf_init2 (op1, BS_FLOAT_PREC_BITS);
     mpf_init2 (op2, BS_FLOAT_PREC_BITS);
 
     mpf_set_z (op1, size->bytes);
-    status = mpf_set_str (op2, float_str, 10);
+    loc_float_str = replace_char_with_str (float_str, '.', radix_char);
+    status = mpf_set_str (op2, loc_float_str, 10);
     if (status != 0) {
-        set_error (error, BS_ERROR_INVALID_SPEC, strdup_printf ("'%s' is not a valid floating point number string", float_str));
+        set_error (error, BS_ERROR_INVALID_SPEC, strdup_printf ("'%s' is not a valid floating point number string", loc_float_str));
+        free (loc_float_str);
         mpf_clears (op1, op2, NULL);
         return NULL;
     }
+    free (loc_float_str);
 
     mpf_mul (op1, op1, op2);
 
@@ -784,17 +791,24 @@ BSSize bs_size_mul_float_str (const BSSize size, const char *float_str, BSError 
 BSSize bs_size_grow_mul_float_str (BSSize size, const char *float_str, BSError **error) {
     mpf_t op1, op2;
     int status = 0;
+    const char *radix_char = NULL;
+    char *loc_float_str = NULL;
+
+    radix_char = nl_langinfo (RADIXCHAR);
 
     mpf_init2 (op1, BS_FLOAT_PREC_BITS);
     mpf_init2 (op2, BS_FLOAT_PREC_BITS);
 
     mpf_set_z (op1, size->bytes);
-    status = mpf_set_str (op2, float_str, 10);
+    loc_float_str = replace_char_with_str (float_str, '.', radix_char);
+    status = mpf_set_str (op2, loc_float_str, 10);
     if (status != 0) {
-        set_error (error, BS_ERROR_INVALID_SPEC, strdup_printf ("'%s' is not a valid floating point number string", float_str));
+        set_error (error, BS_ERROR_INVALID_SPEC, strdup_printf ("'%s' is not a valid floating point number string", loc_float_str));
+        free (loc_float_str);
         mpf_clears (op1, op2, NULL);
         return NULL;
     }
+    free (loc_float_str);
 
     mpf_mul (op1, op1, op2);
 

--- a/tests/libbytesize_unittest.py
+++ b/tests/libbytesize_unittest.py
@@ -3,8 +3,11 @@
 
 import locale
 import unittest
+import sys
 
 from bytesize import SizeStruct, KiB, ROUND_UP, ROUND_DOWN
+
+DEFAULT_LOCALE = "en_US.utf8"
 
 class SizeTestCase(unittest.TestCase):
 
@@ -15,11 +18,11 @@ class SizeTestCase(unittest.TestCase):
     #enddef
 
     def setUp(self):
-        locale.setlocale(locale.LC_ALL,'en_US.utf8')
+        locale.setlocale(locale.LC_ALL, DEFAULT_LOCALE)
     #enddef
 
     def tearDown(self):
-        locale.setlocale(locale.LC_ALL,'en_US.utf8')
+        locale.setlocale(locale.LC_ALL, DEFAULT_LOCALE)
     #enddef
 
     def testNewFromStr(self):
@@ -332,7 +335,7 @@ class SizeTestCase(unittest.TestCase):
         self.assertEqual(strSizeStruct, "12 KiB")
 
         strSizeStruct = SizeStruct.new_from_str("1 KB").human_readable(KiB, 2, False)
-        self.assertEqual(strSizeStruct, "0.98 KiB")
+        self.assertEqual(strSizeStruct, "0%s98 KiB" % locale.nl_langinfo(locale.RADIXCHAR))
 
         strSizeStruct = SizeStruct.new_from_str("100 GiB").human_readable(KiB, 2, False)
         self.assertEqual(strSizeStruct, "100 GiB")
@@ -358,12 +361,12 @@ class SizeTestCase(unittest.TestCase):
     def testTrueDiv(self):
         x = SizeStruct.new_from_str("1024 B")
         y = SizeStruct.new_from_str("-102.4 B") # rounds to whole bytes
-        divResult = float(x.true_div(y)[:15]) # just some number to cover accurancy and not cross max float range
+        divResult = float(x.true_div(y)[:15].replace(locale.nl_langinfo(locale.RADIXCHAR), ".")) # just some number to cover accurancy and not cross max float range
         self.assertAlmostEqual(divResult, 1024.0/-102.0)
 
         x = SizeStruct.new_from_str("1 MiB")
         y = SizeStruct.new_from_str("1 KiB")
-        divResult = float(x.true_div(y)[:15]) # just some number to cover accurancy and not cross max float range
+        divResult = float(x.true_div(y)[:15].replace(locale.nl_langinfo(locale.RADIXCHAR), ".")) # just some number to cover accurancy and not cross max float range
         self.assertAlmostEqual(divResult, 1024.0)
     #enddef
 
@@ -583,6 +586,11 @@ class SizeTestCase(unittest.TestCase):
 
 # script entry point
 if __name__=='__main__':
+    if len(sys.argv) > 1:
+        DEFAULT_LOCALE = sys.argv[1]
+        # the unittest module would try to intepret the argument too, let's
+        # remove it
+        sys.argv = [sys.argv[0]]
     unittest.main()
 #endif
 

--- a/tests/libbytesize_unittest.sh
+++ b/tests/libbytesize_unittest.sh
@@ -7,3 +7,6 @@ fi
 
 python2 ${srcdir}/libbytesize_unittest.py
 python3 ${srcdir}/libbytesize_unittest.py
+
+python2 ${srcdir}/libbytesize_unittest.py fr_FR.UTF8
+python3 ${srcdir}/libbytesize_unittest.py fr_FR.UTF8


### PR DESCRIPTION
The MPFR library doesn't work well with locales and doesn't accept floats as strings if written in the current locale (e.g. ``"1,5"`` in ``fr_FR``). Thus we need to take care about this ourselves. 

Plus we should run the unit tests with such a locale to reveal other potential issues.