### PR TITLE
Try harder when getting OverflowError in division (#1326897)

### DIFF
--- a/src/bs_size.c
+++ b/src/bs_size.c
@@ -829,7 +829,7 @@ uint64_t bs_size_div (const BSSize size1, const BSSize size2, int *sgn, BSError 
     mpz_tdiv_q (result, size1->bytes, size2->bytes);
 
     if (mpz_cmp_ui (result, UINT64_MAX) > 0) {
-        set_error (error, BS_ERROR_OVER, strdup_printf ("The size is too big, cannot be returned as a 64bit number of bytes"));
+        set_error (error, BS_ERROR_OVER, strdup_printf ("The size is too big, cannot be returned as a 64bit number"));
         mpz_clear (result);
         return 0;
     }

--- a/tests/lbs_py_override_unittest.py
+++ b/tests/lbs_py_override_unittest.py
@@ -128,12 +128,20 @@ class SizeTestCase(unittest.TestCase):
         expected = Decimal("1")
         self.assertEqual(actual, expected)
 
+        actual = Size("128 EiB") // Size("64 EiB")
+        expected = 2
+        self.assertEqual(actual, expected)
+
         actual = Size("100 B") / 10
         expected = Decimal("10")
         self.assertEqual(actual, expected)
 
         actual = Size("120 B") / 100
         expected = Decimal("1.2")
+        self.assertEqual(actual, expected)
+
+        actual = Size("128 EiB") // 2
+        expected = Size("64 EiB")
         self.assertEqual(actual, expected)
 
         result = Size("120 B") // 100


### PR DESCRIPTION
We can use the true_div*() functions returning string and then convert such
string into int.