### PR TITLE
Add support for the ROUND_HALF_UP rounding mode

### DIFF
--- a/src/bs_size.h
+++ b/src/bs_size.h
@@ -63,8 +63,9 @@ typedef enum {
  * Rounding direction for rounding operations.
  */
 typedef enum {
-    BS_ROUND_DIR_UP,
-    BS_ROUND_DIR_DOWN,
+    BS_ROUND_DIR_UP = 0,
+    BS_ROUND_DIR_DOWN = 1,
+    BS_ROUND_DIR_HALF_UP = 2
 } BSRoundDir;
 
 /**

--- a/src/python/bytesize.py
+++ b/src/python/bytesize.py
@@ -31,6 +31,7 @@ YB = 28
 
 ROUND_UP = 0
 ROUND_DOWN = 1
+ROUND_HALF_UP = 2
 
 MAXUINT64 = 2**64 - 1
 
@@ -378,7 +379,7 @@ class Size(object):
             raise ValueError("max_places has to be an integer number")
         return self._c_size.human_readable(min_unit, max_places, xlate)
 
-    def round_to_nearest(self, round_to, rounding=ROUND_UP):
+    def round_to_nearest(self, round_to, rounding):
         if isinstance(round_to, Size):
             return self._c_size.round_to_nearest(round_to._c_size, rounding)
 

--- a/tests/libbytesize_unittest.py
+++ b/tests/libbytesize_unittest.py
@@ -5,7 +5,7 @@ import locale
 import unittest
 import sys
 
-from bytesize import SizeStruct, KiB, ROUND_UP, ROUND_DOWN
+from bytesize import SizeStruct, KiB, ROUND_UP, ROUND_DOWN, ROUND_HALF_UP
 
 DEFAULT_LOCALE = "en_US.utf8"
 
@@ -460,6 +460,75 @@ class SizeTestCase(unittest.TestCase):
         roundTo = SizeStruct.new_from_str("10 KiB")
         actual = x.round_to_nearest(roundTo, ROUND_DOWN).get_bytes()
         expected = (0, 0)
+        self.assertEqual(actual, expected)
+
+        x = SizeStruct.new_from_str("1024 B")
+        roundTo = SizeStruct.new_from_str("1 KiB")
+        actual = x.round_to_nearest(roundTo, ROUND_DOWN).get_bytes()
+        expected = (1024, 1)
+        self.assertEqual(actual, expected)
+        actual = x.round_to_nearest(roundTo, ROUND_UP).get_bytes()
+        expected = (1024, 1)
+        self.assertEqual(actual, expected)
+        actual = x.round_to_nearest(roundTo, ROUND_HALF_UP).get_bytes()
+        expected = (1024, 1)
+        self.assertEqual(actual, expected)
+
+        x = SizeStruct.new_from_str("1023 B")
+        actual = x.round_to_nearest(roundTo, ROUND_DOWN).get_bytes()
+        expected = (0, 0)
+        self.assertEqual(actual, expected)
+        actual = x.round_to_nearest(roundTo, ROUND_UP).get_bytes()
+        expected = (1024, 1)
+        self.assertEqual(actual, expected)
+        actual = x.round_to_nearest(roundTo, ROUND_HALF_UP).get_bytes()
+        expected = (1024, 1)
+        self.assertEqual(actual, expected)
+
+        x = SizeStruct.new_from_str("1025 B")
+        actual = x.round_to_nearest(roundTo, ROUND_DOWN).get_bytes()
+        expected = (1024, 1)
+        self.assertEqual(actual, expected)
+        actual = x.round_to_nearest(roundTo, ROUND_UP).get_bytes()
+        expected = (2048, 1)
+        self.assertEqual(actual, expected)
+        actual = x.round_to_nearest(roundTo, ROUND_HALF_UP).get_bytes()
+        expected = (1024, 1)
+        self.assertEqual(actual, expected)
+
+        x = SizeStruct.new_from_str("1535 B")
+        actual = x.round_to_nearest(roundTo, ROUND_DOWN).get_bytes()
+        expected = (1024, 1)
+        self.assertEqual(actual, expected)
+        actual = x.round_to_nearest(roundTo, ROUND_UP).get_bytes()
+        expected = (2048, 1)
+        self.assertEqual(actual, expected)
+        actual = x.round_to_nearest(roundTo, ROUND_HALF_UP).get_bytes()
+        expected = (1024, 1)
+        self.assertEqual(actual, expected)
+
+        x = SizeStruct.new_from_str("1536 B")
+        actual = x.round_to_nearest(roundTo, ROUND_DOWN).get_bytes()
+        expected = (1024, 1)
+        self.assertEqual(actual, expected)
+        actual = x.round_to_nearest(roundTo, ROUND_UP).get_bytes()
+        expected = (2048, 1)
+        self.assertEqual(actual, expected)
+        actual = x.round_to_nearest(roundTo, ROUND_HALF_UP).get_bytes()
+        expected = (2048, 1)
+        self.assertEqual(actual, expected)
+
+        # now check something bigger
+        x = SizeStruct.new_from_str("575 GiB")
+        roundTo = SizeStruct.new_from_str("128 GiB")
+        actual = x.round_to_nearest(roundTo, ROUND_HALF_UP).get_bytes_str()
+        expected = SizeStruct.new_from_str("512 GiB").get_bytes_str()
+        self.assertEqual(actual, expected)
+
+        x = SizeStruct.new_from_str("576 GiB")
+        roundTo = SizeStruct.new_from_str("128 GiB")
+        actual = x.round_to_nearest(roundTo, ROUND_HALF_UP).get_bytes_str()
+        expected = SizeStruct.new_from_str("640 GiB").get_bytes_str()
         self.assertEqual(actual, expected)
     #enddef
 


### PR DESCRIPTION
One has to be really careful with this mode in relation to storage sizes, but it
could potentially be useful in some cases for some simplified overviews or
something like that.