### PR TITLE
Beware of unsigned long int on 32bit arches (#1333149)

### DIFF
--- a/tests/libbytesize_unittest.py
+++ b/tests/libbytesize_unittest.py
@@ -123,6 +123,12 @@ class SizeTestCase(unittest.TestCase):
         actual = SizeStruct.new_from_bytes(1024, -1).get_bytes()
         expected = (1024, -1)
         self.assertEqual(actual, expected)
+
+        # now let's try something bigger than MAXUINT32
+        actual = SizeStruct.new_from_bytes(5718360*1024, 1).get_bytes()
+        expected = (5718360*1024, 1)
+        self.assertEqual(actual, expected)
+
     #enddef
 
     def testNewFromSizeStruct(self):


### PR DESCRIPTION
GMP has no function to assign an mpz_t instance from usigned long long int and
unsigned long int may be just a 32bit number on some architectures. So let's
just convert the number we get into a string and use the initializer from string
instead.