### PR TITLE
Fix 'make local'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -73,7 +73,8 @@ bumpver:
 archive: po-pull
 	$(MAKE) distcheck
 
-local: po-empty
+local: all
+	[ -f ./po/en_US.po ] || msginit -i ./po/$(PACKAGE_NAME).pot -o ./po/en_US.po --no-translator
 	$(MAKE) dist
 
 srpm: local


### PR DESCRIPTION
'po-empty' target used in 'local' has been removed in a98db82, but
having at least some l10n files is necessary for building rpms and
we don't want to download them using 'po-pull' for testing builds.