### PR TITLE
Fix issues preventing us from building libbytesize for RHEL 7

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,10 @@
 ACLOCAL_AMFLAGS = -I m4
 DISTCHECK_CONFIGURE_FLAGS = --enable-introspection
 
-SUBDIRS = . po src dist docs tests
+SUBDIRS = . po src dist tests
+if WITH_GTK_DOC
+SUBDIRS += docs
+endif
 
 dist_noinst_DATA = LICENSE README.rst
 

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,11 @@ AC_CHECK_HEADERS([langinfo.h gmp.h mpfr.h stdint.h stdbool.h stdarg.h string.h s
                  [LIBBYTESIZE_SOFT_FAILURE([Header file $ac_header not found.])],
                  [])
 
+AC_SUBST([PYTHON_EXEC_PREFIX], ['${exec_prefix}'])
+      PYTHON_EXECDIR=`python -c "import distutils.sysconfig; \
+                                print(distutils.sysconfig.get_python_lib(1,0,prefix='${exec_prefix}'))"`
+      AC_SUBST(pyexecdir, $PYTHON_EXECDIR)
+
 AC_ARG_WITH([python3],
     AS_HELP_STRING([--with-python3], [support python3 @<:@default=check@:>@]),
     [],

--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,7 @@ AC_ARG_WITH([python3],
     [],
     [with_python3=check])
 
+AC_SUBST(WITH_PYTHON3, 0)
 if test "x$with_python3" != "xno"; then
     AC_PATH_PROG([python3], [python3], [no])
     AS_IF([test "x$python3" == "xno"],
@@ -57,7 +58,8 @@ if test "x$with_python3" != "xno"; then
     [AC_SUBST([PYTHON3_EXEC_PREFIX], ['${exec_prefix}'])
       PYTHON3_EXECDIR=`$python3 -c "import distutils.sysconfig; \
                                 print(distutils.sysconfig.get_python_lib(1,0,prefix='${exec_prefix}'))"`
-      AC_SUBST(py3execdir, $PYTHON3_EXECDIR)])
+      AC_SUBST(py3execdir, $PYTHON3_EXECDIR)
+      AC_SUBST(WITH_PYTHON3, 1)])
 fi
 AM_CONDITIONAL(WITH_PYTHON3, test "x$with_python3" != "xno" -a "x$python3" != "xno")
 
@@ -67,13 +69,14 @@ AC_ARG_WITH([gtk-doc],
     [],
     [with_gtk_doc=check])
 
+AC_SUBST(WITH_GTK_DOC, 0)
 if test "x$with_gtk_doc" != "xno"; then
     AC_PATH_PROG([gtkdoc_scan], [gtkdoc-scan], [no])
     AS_IF([test "x$gtkdoc_scan" == "xno"],
     [if test "x$with_gtk_doc" = "xyes"; then
       LIBBYTESIZE_SOFT_FAILURE([Building documentation with gtk-doc requested, but not available])
       fi],
-      [])
+      [AC_SUBST(WITH_GTK_DOC, 1)])
 fi
 AM_CONDITIONAL(WITH_GTK_DOC, test "x$with_gtk_doc" != "xno" -a "x$gtkdoc_scan" != "xno")
 

--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ AC_CONFIG_FILES([Makefile src/Makefile src/bytesize.pc \
                  docs/Makefile docs/libbytesize-docs.xml \
                  tests/Makefile])
 
-LIBBYTESIZE_PKG_CHECK_MODULES([PCRE], [libpcre >= 8.38])
+LIBBYTESIZE_PKG_CHECK_MODULES([PCRE], [libpcre >= 8.32])
 
 AC_PATH_PROG([PYTHON3], [python3], [no])
 AS_IF([test "x$PYTHON3" == "xno"], [LIBBYTESIZE_SOFT_FAILURE([\

--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,13 @@ AC_CONFIG_FILES([Makefile src/Makefile src/bytesize.pc \
                  docs/Makefile docs/libbytesize-docs.xml \
                  tests/Makefile])
 
+AC_CONFIG_FILES([tests/libbytesize_unittest.sh],
+                [chmod +x tests/libbytesize_unittest.sh])
+
+AC_CONFIG_FILES([tests/canary_tests.sh],
+                [chmod +x tests/canary_tests.sh])
+
+
 LIBBYTESIZE_PKG_CHECK_MODULES([PCRE], [libpcre >= 8.32])
 
 AC_CHECK_LIB(gmp, __gmpz_init)

--- a/configure.ac
+++ b/configure.ac
@@ -36,22 +36,30 @@ AC_CONFIG_FILES([Makefile src/Makefile src/bytesize.pc \
 
 LIBBYTESIZE_PKG_CHECK_MODULES([PCRE], [libpcre >= 8.32])
 
-AC_PATH_PROG([PYTHON3], [python3], [no])
-AS_IF([test "x$PYTHON3" == "xno"], [LIBBYTESIZE_SOFT_FAILURE([\
-      The python3 program was not found in the search path. Please ensure that it is installed and its directory is included in the search path.])],
-      [:])
-
-AC_SUBST([PYTHON3_EXEC_PREFIX], ['${exec_prefix}'])
-PYTHON3_EXECDIR=`$PYTHON3 -c "import distutils.sysconfig; \
-                          print(distutils.sysconfig.get_python_lib(1,0,prefix='$PYTHON3_EXEC_PREFIX'))"`
-AC_SUBST(py3execdir, $PYTHON3_EXECDIR)
-
 AC_CHECK_LIB(gmp, __gmpz_init)
 
 AC_CHECK_HEADERS([langinfo.h gmp.h mpfr.h stdint.h stdbool.h stdarg.h string.h stdio.h ctype.h],
                  [],
                  [LIBBYTESIZE_SOFT_FAILURE([Header file $ac_header not found.])],
                  [])
+
+AC_ARG_WITH([python3],
+    AS_HELP_STRING([--with-python3], [support python3 @<:@default=check@:>@]),
+    [],
+    [with_python3=check])
+
+if test "x$with_python3" != "xno"; then
+    AC_PATH_PROG([python3], [python3], [no])
+    AS_IF([test "x$python3" == "xno"],
+    [if test "x$with_python3" = "xyes"; then
+      LIBBYTESIZE_SOFT_FAILURE([Python3 support requested, but python3 is not available])
+      fi],
+    [AC_SUBST([PYTHON3_EXEC_PREFIX], ['${exec_prefix}'])
+      PYTHON3_EXECDIR=`$python3 -c "import distutils.sysconfig; \
+                                print(distutils.sysconfig.get_python_lib(1,0,prefix='${exec_prefix}'))"`
+      AC_SUBST(py3execdir, $PYTHON3_EXECDIR)])
+fi
+AM_CONDITIONAL(WITH_PYTHON3, test "x$with_python3" != "xno" -a "x$python3" != "xno")
 
 AC_OUTPUT
 LIBBYTESIZE_FAILURES

--- a/configure.ac
+++ b/configure.ac
@@ -61,5 +61,21 @@ if test "x$with_python3" != "xno"; then
 fi
 AM_CONDITIONAL(WITH_PYTHON3, test "x$with_python3" != "xno" -a "x$python3" != "xno")
 
+
+AC_ARG_WITH([gtk-doc],
+    AS_HELP_STRING([--with-gtk-doc], [generate documentation with gtk-doc @<:@default=check@:>@]),
+    [],
+    [with_gtk_doc=check])
+
+if test "x$with_gtk_doc" != "xno"; then
+    AC_PATH_PROG([gtkdoc_scan], [gtkdoc-scan], [no])
+    AS_IF([test "x$gtkdoc_scan" == "xno"],
+    [if test "x$with_gtk_doc" = "xyes"; then
+      LIBBYTESIZE_SOFT_FAILURE([Building documentation with gtk-doc requested, but not available])
+      fi],
+      [])
+fi
+AM_CONDITIONAL(WITH_GTK_DOC, test "x$with_gtk_doc" != "xno" -a "x$gtkdoc_scan" != "xno")
+
 AC_OUTPUT
 LIBBYTESIZE_FAILURES

--- a/dist/libbytesize.spec.in
+++ b/dist/libbytesize.spec.in
@@ -1,3 +1,15 @@
+%define realname bytesize
+%define with_python3 @WITH_PYTHON3@
+%define with_gtk_doc @WITH_GTK_DOC@
+
+%define is_rhel 0%{?rhel} != 0
+
+# python3 is not available on RHEL
+%if %{is_rhel}
+%define with_python3 0
+%define configure_opts --without-python3
+%endif
+
 Name:        libbytesize
 Version:     0.8
 Release:     1%{?dist}
@@ -5,10 +17,6 @@ Summary:     A library for working with sizes in bytes
 License:     LGPLv2+
 URL:         https://github.com/rhinstaller/libbytesize
 Source0:     https://github.com/rhinstaller/libbytesize/archive/%{name}-%{version}.tar.gz
-
-%define realname bytesize
-%define with_python3 @WITH_PYTHON3@
-%define with_gtk_doc @WITH_GTK_DOC@
 
 BuildRequires: gmp-devel
 BuildRequires: mpfr-devel
@@ -61,7 +69,7 @@ the library from Python 3 easier and more convenient.
 %setup -q -n %{name}-%{version}
 
 %build
-%configure
+%configure %{?configure_opts}
 %{__make} %{?_smp_mflags}
 
 %install

--- a/dist/libbytesize.spec.in
+++ b/dist/libbytesize.spec.in
@@ -7,14 +7,20 @@ URL:         https://github.com/rhinstaller/libbytesize
 Source0:     https://github.com/rhinstaller/libbytesize/archive/%{name}-%{version}.tar.gz
 
 %define realname bytesize
+%define with_python3 @WITH_PYTHON3@
+%define with_gtk_doc @WITH_GTK_DOC@
 
 BuildRequires: gmp-devel
 BuildRequires: mpfr-devel
 BuildRequires: pcre-devel
 BuildRequires: gettext-devel
 BuildRequires: python-devel
+%if %{with_python3}
 BuildRequires: python3-devel
+%endif
+%if %{with_gtk_doc}
 BuildRequires: gtk-doc
+%endif
 
 %description
 The libbytesize is a C library that facilitates work with sizes in
@@ -40,6 +46,7 @@ Requires: python-six
 This package contains Python 2 bindings for libbytesize making the use of
 the library from Python 2 easier and more convenient.
 
+%if %{with_python3}
 %package -n python3-%{realname}
 Summary: Python 3 bindings for libbytesize
 Requires: %{name}%{?_isa} = %{version}-%{release}
@@ -48,6 +55,7 @@ Requires: python3-six
 %description -n python3-%{realname}
 This package contains Python 3 bindings for libbytesize making the use of
 the library from Python 3 easier and more convenient.
+%endif
 
 %prep
 %setup -q -n %{name}-%{version}
@@ -77,16 +85,20 @@ find %{buildroot} -type f -name "*.la" | xargs %{__rm}
 %dir %{_includedir}/bytesize
 %{_includedir}/bytesize/bs_size.h
 %{_libdir}/pkgconfig/bytesize.pc
+%if %{with_gtk_doc}
 %{_datadir}/gtk-doc/html/libbytesize
+%endif
 
 %files -n python-%{realname}
 %dir %{python2_sitearch}/bytesize
 %{python2_sitearch}/bytesize/*
 
+%if %{with_python3}
 %files -n python3-%{realname}
 %dir %{python3_sitearch}/bytesize
 %{python3_sitearch}/bytesize/*
 %{python3_sitearch}/bytesize/__pycache__/*
+%endif
 
 %changelog
 * Fri Dec 16 2016 Vratislav Podzimek <vpodzime@redhat.com> - 0.8-1

--- a/src/python/Makefile.am
+++ b/src/python/Makefile.am
@@ -1,7 +1,9 @@
 pybytesizedir     = $(pyexecdir)/bytesize
-py3bytesizedir    = $(py3execdir)/bytesize
-
 dist_pybytesize_DATA = bytesize.py __init__.py
+
+if WITH_PYTHON3
+py3bytesizedir    = $(py3execdir)/bytesize
 nodist_py3bytesize_DATA = bytesize.py __init__.py
+endif
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/tests/canary_tests.sh.in
+++ b/tests/canary_tests.sh.in
@@ -1,6 +1,11 @@
 #!/bin/sh -e
 # Run the translation canary tests on the translatable strings
 
+if [ @WITH_PYTHON3@ != 1 ]; then
+    echo "Cannot run translations tests without python3, skipping."
+    exit 0
+fi
+
 # If not run from automake, fake it
 if [ -z "$top_srcdir" ]; then
     top_srcdir="$(dirname "$0")/.."

--- a/tests/libbytesize_unittest.sh.in
+++ b/tests/libbytesize_unittest.sh.in
@@ -6,7 +6,12 @@ if [ -z "$srcdir" ]; then
 fi
 
 python2 ${srcdir}/libbytesize_unittest.py
-python3 ${srcdir}/libbytesize_unittest.py
+if [ @WITH_PYTHON3@ = 1 ]; then
+    python3 ${srcdir}/libbytesize_unittest.py
+fi
 
 python2 ${srcdir}/libbytesize_unittest.py fr_FR.UTF8
-python3 ${srcdir}/libbytesize_unittest.py fr_FR.UTF8
+
+if [ @WITH_PYTHON3@ = 1 ]; then
+    python3 ${srcdir}/libbytesize_unittest.py fr_FR.UTF8
+fi


### PR DESCRIPTION
With these patches *libbytesize* can successfully be built on RHEL 7. This is what needs to be done:

- [x] build with Python 3 not being available
- [x] build with gtk-doc not being available
- [x] only run Python 2 tests if Python 3 is not available