### PR TITLE
Fix installation without specifying --exec-prefix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,11 +50,6 @@ AC_CHECK_HEADERS([langinfo.h gmp.h mpfr.h stdint.h stdbool.h stdarg.h string.h s
                  [LIBBYTESIZE_SOFT_FAILURE([Header file $ac_header not found.])],
                  [])
 
-AC_SUBST([PYTHON_EXEC_PREFIX], ['${exec_prefix}'])
-      PYTHON_EXECDIR=`python -c "import distutils.sysconfig; \
-                                print(distutils.sysconfig.get_python_lib(1,0,prefix='${exec_prefix}'))"`
-      AC_SUBST(pyexecdir, $PYTHON_EXECDIR)
-
 AC_ARG_WITH([python3],
     AS_HELP_STRING([--with-python3], [support python3 @<:@default=check@:>@]),
     [],
@@ -67,11 +62,7 @@ if test "x$with_python3" != "xno"; then
     [if test "x$with_python3" = "xyes"; then
       LIBBYTESIZE_SOFT_FAILURE([Python3 support requested, but python3 is not available])
       fi],
-    [AC_SUBST([PYTHON3_EXEC_PREFIX], ['${exec_prefix}'])
-      PYTHON3_EXECDIR=`$python3 -c "import distutils.sysconfig; \
-                                print(distutils.sysconfig.get_python_lib(1,0,prefix='${exec_prefix}'))"`
-      AC_SUBST(py3execdir, $PYTHON3_EXECDIR)
-      AC_SUBST(WITH_PYTHON3, 1)])
+    [AC_SUBST(WITH_PYTHON3, 1)])
 fi
 AM_CONDITIONAL(WITH_PYTHON3, test "x$with_python3" != "xno" -a "x$python3" != "xno")
 

--- a/src/python/Makefile.am
+++ b/src/python/Makefile.am
@@ -1,8 +1,11 @@
-pybytesizedir     = $(pyexecdir)/bytesize
+pylibdir = $(shell python -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_lib(1,0,prefix='${exec_prefix}'))")
+
+pybytesizedir     = $(pylibdir)/bytesize
 dist_pybytesize_DATA = bytesize.py __init__.py
 
 if WITH_PYTHON3
-py3bytesizedir    = $(py3execdir)/bytesize
+py3libdir = $(shell python3 -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_lib(1,0,prefix='${exec_prefix}'))")
+py3bytesizedir    = $(py3libdir)/bytesize
 nodist_py3bytesize_DATA = bytesize.py __init__.py
 endif
 


### PR DESCRIPTION
${exec_prefix} cannot be used in configure.ac yet, as its "NONE" default
gets expaneded only later. Move the python library directory detection
to src/python/Makefile.am instead.

Fixes #25

--- 

I tested this with a default `./configure` and `./configure --prefix=/usr`, and it now correctly installs the Python modules, not into `$DESTDIR/NONE` any more.