### PR TITLE
Skip tests if they require unavailable locales

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,6 @@
 AM_TESTS_ENVIRONMENT = top_srcdir="$(top_srcdir)" top_builddir="$(top_builddir)" ; . $(srcdir)/testenv.sh ;
 
-dist_noinst_SCRIPTS = libbytesize_unittest.sh libbytesize_unittest.py lbs_py_override_unittest.py testenv.sh canary_tests.sh
+dist_noinst_SCRIPTS = libbytesize_unittest.sh libbytesize_unittest.py lbs_py_override_unittest.py locale_utils.py testenv.sh canary_tests.sh
 
 TESTS = libbytesize_unittest.sh lbs_py_override_unittest.py canary_tests.sh
 

--- a/tests/lbs_py_override_unittest.py
+++ b/tests/lbs_py_override_unittest.py
@@ -6,11 +6,18 @@ import copy
 import locale
 
 from decimal import Decimal
+from locale_utils import get_avail_locales, requires_locales
 
 from bytesize import Size
 
 class SizeTestCase(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        unittest.TestCase.setUpClass()
+        cls.avail_locales = get_avail_locales()
+
+    @requires_locales({'en_US.utf8'})
     def setUp(self):
         locale.setlocale(locale.LC_ALL,'en_US.utf8')
         self.addCleanup(self._clean_up)
@@ -274,6 +281,7 @@ class SizeTestCase(unittest.TestCase):
         size_set = set((Size("1 KiB"), Size("1 KiB"), Size("1 KiB"), Size("2 KiB"), Size(0)))
         self.assertEqual(len(size_set), 3)
 
+    @requires_locales({'cs_CZ.UTF-8', 'ps_AF.UTF-8', 'en_US.UTF-8'})
     def testConvertTo(self):
         size = Size("1.5 KiB")
         conv = size.convert_to("KiB")

--- a/tests/libbytesize_unittest.py
+++ b/tests/libbytesize_unittest.py
@@ -5,26 +5,33 @@ import locale
 import unittest
 import sys
 
+from locale_utils import get_avail_locales, requires_locales
+
 from bytesize import SizeStruct, KiB, ROUND_UP, ROUND_DOWN, ROUND_HALF_UP
 
 DEFAULT_LOCALE = "en_US.utf8"
 
 class SizeTestCase(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        unittest.TestCase.setUpClass()
+        cls.avail_locales = get_avail_locales()
+
+    @requires_locales({DEFAULT_LOCALE})
+    def setUp(self):
+        locale.setlocale(locale.LC_ALL, DEFAULT_LOCALE)
+        self.addCleanup(self._clean_up)
+
+    def _clean_up(self):
+        locale.setlocale(locale.LC_ALL, DEFAULT_LOCALE)
+
     def testNew(self):
         actual = SizeStruct.new().get_bytes()
         expected = (0, 0)
         self.assertEqual(actual, expected)
-    #enddef
 
-    def setUp(self):
-        locale.setlocale(locale.LC_ALL, DEFAULT_LOCALE)
-    #enddef
-
-    def tearDown(self):
-        locale.setlocale(locale.LC_ALL, DEFAULT_LOCALE)
-    #enddef
-
+    @requires_locales({'cs_CZ.UTF-8', 'ps_AF.UTF-8', 'en_US.UTF-8'})
     def testNewFromStr(self):
         actual = SizeStruct.new_from_str('0 B').get_bytes()
         expected = (0, 0)
@@ -107,7 +114,7 @@ class SizeTestCase(unittest.TestCase):
         expected = (1536, -1)
         self.assertEqual(actual, expected)
 
-        locale.setlocale(locale.LC_ALL,'en_US.UTF-8')
+        locale.setlocale(locale.LC_ALL, DEFAULT_LOCALE)
 
     #enddef
 
@@ -336,6 +343,7 @@ class SizeTestCase(unittest.TestCase):
         self.assertEqual(strSizeStruct, "-1024")
     #enddef
 
+    @requires_locales({'cs_CZ.UTF-8'})
     def testHumanReadable(self):
         strSizeStruct = SizeStruct.new_from_str("12 KiB").human_readable(KiB, 2, False)
         self.assertEqual(strSizeStruct, "12 KiB")

--- a/tests/locale_utils.py
+++ b/tests/locale_utils.py
@@ -1,0 +1,30 @@
+
+import subprocess
+
+"""Helper functions, decorators,... for working with locales"""
+
+def get_avail_locales():
+    return {loc.strip() for loc in subprocess.check_output(["locale", "-a"]).split()}
+
+def requires_locales(locales):
+    """A decorator factory to skip tests that require unavailable locales
+
+    :param set locales: set of required locales
+
+    **Requires the test to have the set of available locales defined as its
+    ``avail_locales`` attribute.**
+
+    """
+
+    canon_locales = {loc.replace("UTF-8", "utf8") for loc in locales}
+    def decorator(test_method):
+        def decorated(test, *args):
+            missing = canon_locales - set(test.avail_locales)
+            if missing:
+                test.skipTest("requires missing locales: %s" % missing)
+            else:
+                return test_method(test, *args)
+
+        return decorated
+
+    return decorator


### PR DESCRIPTION
Otherwise they fail with a traceback.

Fixes #27.